### PR TITLE
Uncapitalize `APP`, `SERVICE`

### DIFF
--- a/dockwrap.sh
+++ b/dockwrap.sh
@@ -224,8 +224,8 @@ cat > $PWD/dockwrap-env << EOL
 ## Configuration variables
 
 # This is the Docker tag to use
-APP="$(basename $(dirname $PWD))"
-SERVICE="$(basename $PWD)"
+APP="$(echo $(basename $(dirname $PWD)) | tr '[A-Z]' '[a-z]')"
+SERVICE="$(echo $(basename $PWD) |  tr '[A-Z]' '[a-z]')"
 
 TAG="\$APP/\$SERVICE"
 VERSION="latest"


### PR DESCRIPTION
An error will occur if the directory name contains uppercase letters.

```bash
$ cat dockwrap-env | head -7
#!/bin/bash

## Configuration variables

# This is the Docker tag to use
APP="Codes"
SERVICE="dockwrap-try"
```

```bash
$ dockwrap build
invalid argument "Codes/dockwrap-try:latest" for t: invalid reference format: repository name must be lowercase
See 'docker build --help'.

$ docker -v
Docker version 17.06.0-ce, build 02c1d87
```

### references
https://www.cyberciti.biz/faq/linux-unix-shell-programming-converting-lowercase-uppercase/